### PR TITLE
Fixed wrong query extraction for Giphy module

### DIFF
--- a/modules/giphy/giphy.js
+++ b/modules/giphy/giphy.js
@@ -45,7 +45,7 @@ exports.search = function (query, callback, waitCallback) {
                         length: images.length
                     };
                 }
-                callback(image);
+                callback({url: image});
             }
             else {
                 callback({error:'No images found.'});
@@ -79,9 +79,12 @@ exports.run = function(api, event) {
     }
 
     exports.search(query, function(image) {
-            if (image) {
-                var url = exports.ensureExt(image);
+            if (image.hasOwnProperty('url')) {
+                var url = exports.ensureExt(image.url);
                 api.sendImage("url", url, "I found this:", event.thread_id);
+            }
+            else if(image.hasOwnProperty('error')) {
+                api.sendMessage(image.error, event.thread_id);
             }
             else {
                 api.sendMessage("Something went very wrong.", event.thread_id);

--- a/modules/giphy/giphy.js
+++ b/modules/giphy/giphy.js
@@ -71,7 +71,13 @@ exports.run = function(api, event) {
         return;
     }
 
-    var query = event.body.substr(6);
+    var query = event.body.substr(5);
+
+    if(!query || query.length == 0) {
+        api.sendMessage("Of course, I'll look for an empty string!", event.thread_id);
+        return;
+    }
+
     exports.search(query, function(image) {
             if (image) {
                 var url = exports.ensureExt(image);

--- a/modules/giphy/kassy.json
+++ b/modules/giphy/kassy.json
@@ -1,5 +1,5 @@
 ﻿{
   "name": "giphy",
-  "version": 2.0,
+  "version": 2.1,
   "startup": "giphy.js"
 }


### PR DESCRIPTION
Query extraction from event.body was wrong, first letter was missing. For example from "/gif cat", extracted query was just "at". Maybe it has something to do with #68 .