### PR TITLE
Update platform.js to handle null as a literal

### DIFF
--- a/core/platform.js
+++ b/core/platform.js
@@ -43,7 +43,6 @@ Platform.prototype.handleTransaction = function(module, args) {
 };
 
 Platform.prototype.messageRxd = function(api, event) {
-    event.sender_name += ""; // Accept sender_name  = null as a literal
     var matchArgs = [event.body, api.commandPrefix, event.thread_id, event.sender_name],
         runArgs = [api, event],
         abort = false;

--- a/core/platform.js
+++ b/core/platform.js
@@ -43,6 +43,7 @@ Platform.prototype.handleTransaction = function(module, args) {
 };
 
 Platform.prototype.messageRxd = function(api, event) {
+    event.sender_name += ""; // Accept sender_name  = null as a literal
     var matchArgs = [event.body, api.commandPrefix, event.thread_id, event.sender_name],
         runArgs = [api, event],
         abort = false;

--- a/core/shim.js
+++ b/core/shim.js
@@ -81,7 +81,7 @@ exports.createEvent = function(thread, senderId, senderName, message) {
 	return {
 		thread_id: thread,
 		sender_id: senderId,
-		sender_name: senderName,
+		sender_name: senderName + "", // Accept sender_name  = null as a literal
 		body: message
 	};
 };


### PR DESCRIPTION
The patch is only applied to `sender_name` as other fields are not chosen by the user.
Unsure if `event.body` requires it as well